### PR TITLE
enable babel-plugin-espower

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["babel-plugin-espower"],
   "optional": ["es7.decorators"]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/popkirby/react-props-decorators.git"
   },
   "scripts": {
-    "build": "babel ./index.js -o lib/index.js",
+    "build": "mkdir -p lib && babel ./index.js -o lib/index.js",
     "test": "npm run build && babel ./test/cases --out-dir ./test/cc && mocha --reporter dot ./test/cc/*_test.js",
     "clean": "rm -rf ./lib ./test/cc"
   },


### PR DESCRIPTION
Hi, thank you for using babel-plugin-espower!
However, babel-plugin-espower is not enabled in your `.babelrc`. Here is the fix.
Thanks.
